### PR TITLE
Converted ToSql usage to impl IntoIterator

### DIFF
--- a/postgres/src/client.rs
+++ b/postgres/src/client.rs
@@ -77,9 +77,15 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn execute<T>(&mut self, query: &T, params: &[&dyn ToSql]) -> Result<u64, Error>
+    pub fn execute<T, I>(
+        &mut self,
+        query: &T,
+        params: impl IntoIterator<IntoIter = I, Item = I::Item>,
+    ) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement,
+        I: Iterator,
+        I::Item: ToSql,
     {
         let statement = query.__statement(self)?;
         self.0.execute(&statement, params).wait()
@@ -116,9 +122,15 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn query<T>(&mut self, query: &T, params: &[&dyn ToSql]) -> Result<Vec<Row>, Error>
+    pub fn query<T, I>(
+        &mut self,
+        query: &T,
+        params: impl IntoIterator<IntoIter = I, Item = I::Item>,
+    ) -> Result<Vec<Row>, Error>
     where
         T: ?Sized + ToStatement,
+        I: Iterator,
+        I::Item: ToSql,
     {
         self.query_iter(query, params)?.collect()
     }
@@ -148,13 +160,15 @@ impl Client {
     /// }
     /// # Ok(())
     /// # }
-    pub fn query_iter<T>(
+    pub fn query_iter<T, I>(
         &mut self,
         query: &T,
-        params: &[&dyn ToSql],
+        params: impl IntoIterator<IntoIter = I, Item = I::Item>,
     ) -> Result<QueryIter<'_>, Error>
     where
         T: ?Sized + ToStatement,
+        I: Iterator,
+        I::Item: ToSql,
     {
         let statement = query.__statement(self)?;
         Ok(QueryIter::new(self.0.query(&statement, params)))
@@ -234,14 +248,16 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn copy_in<T, R>(
+    pub fn copy_in<T, I, R>(
         &mut self,
         query: &T,
-        params: &[&dyn ToSql],
+        params: impl IntoIterator<IntoIter = I, Item = I::Item>,
         reader: R,
     ) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement,
+        I: Iterator,
+        I::Item: ToSql,
         R: Read,
     {
         let statement = query.__statement(self)?;
@@ -269,13 +285,15 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn copy_out<T>(
+    pub fn copy_out<T, I>(
         &mut self,
         query: &T,
-        params: &[&dyn ToSql],
+        params: impl IntoIterator<IntoIter = I, Item = I::Item>,
     ) -> Result<CopyOutReader<'_>, Error>
     where
         T: ?Sized + ToStatement,
+        I: Iterator,
+        I::Item: ToSql,
     {
         let statement = query.__statement(self)?;
         let stream = self.0.copy_out(&statement, params);

--- a/postgres/src/test.rs
+++ b/postgres/src/test.rs
@@ -45,12 +45,12 @@ fn transaction_commit() {
     let mut transaction = client.transaction().unwrap();
 
     transaction
-        .execute("INSERT INTO foo DEFAULT VALUES", &[])
+        .execute("INSERT INTO foo DEFAULT VALUES", &[] as &[i32])
         .unwrap();
 
     transaction.commit().unwrap();
 
-    let rows = client.query("SELECT * FROM foo", &[]).unwrap();
+    let rows = client.query("SELECT * FROM foo", &[] as &[i32]).unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].get::<_, i32>(0), 1);
 }
@@ -66,12 +66,12 @@ fn transaction_rollback() {
     let mut transaction = client.transaction().unwrap();
 
     transaction
-        .execute("INSERT INTO foo DEFAULT VALUES", &[])
+        .execute("INSERT INTO foo DEFAULT VALUES", &[] as &[i32])
         .unwrap();
 
     transaction.rollback().unwrap();
 
-    let rows = client.query("SELECT * FROM foo", &[]).unwrap();
+    let rows = client.query("SELECT * FROM foo", &[] as &[i32]).unwrap();
     assert_eq!(rows.len(), 0);
 }
 
@@ -86,12 +86,12 @@ fn transaction_drop() {
     let mut transaction = client.transaction().unwrap();
 
     transaction
-        .execute("INSERT INTO foo DEFAULT VALUES", &[])
+        .execute("INSERT INTO foo DEFAULT VALUES", &[] as &[i32])
         .unwrap();
 
     drop(transaction);
 
-    let rows = client.query("SELECT * FROM foo", &[]).unwrap();
+    let rows = client.query("SELECT * FROM foo", &[] as &[i32]).unwrap();
     assert_eq!(rows.len(), 0);
 }
 
@@ -106,19 +106,19 @@ fn nested_transactions() {
     let mut transaction = client.transaction().unwrap();
 
     transaction
-        .execute("INSERT INTO foo (id) VALUES (1)", &[])
+        .execute("INSERT INTO foo (id) VALUES (1)", &[] as &[i32])
         .unwrap();
 
     let mut transaction2 = transaction.transaction().unwrap();
 
     transaction2
-        .execute("INSERT INTO foo (id) VALUES (2)", &[])
+        .execute("INSERT INTO foo (id) VALUES (2)", &[] as &[i32])
         .unwrap();
 
     transaction2.rollback().unwrap();
 
     let rows = transaction
-        .query("SELECT id FROM foo ORDER BY id", &[])
+        .query("SELECT id FROM foo ORDER BY id", &[] as &[i32])
         .unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].get::<_, i32>(0), 1);
@@ -126,20 +126,22 @@ fn nested_transactions() {
     let mut transaction3 = transaction.transaction().unwrap();
 
     transaction3
-        .execute("INSERT INTO foo (id) VALUES(3)", &[])
+        .execute("INSERT INTO foo (id) VALUES(3)", &[] as &[i32])
         .unwrap();
 
     let mut transaction4 = transaction3.transaction().unwrap();
 
     transaction4
-        .execute("INSERT INTO foo (id) VALUES(4)", &[])
+        .execute("INSERT INTO foo (id) VALUES(4)", &[] as &[i32])
         .unwrap();
 
     transaction4.commit().unwrap();
     transaction3.commit().unwrap();
     transaction.commit().unwrap();
 
-    let rows = client.query("SELECT id FROM foo ORDER BY id", &[]).unwrap();
+    let rows = client
+        .query("SELECT id FROM foo ORDER BY id", &[] as &[i32])
+        .unwrap();
     assert_eq!(rows.len(), 3);
     assert_eq!(rows[0].get::<_, i32>(0), 1);
     assert_eq!(rows[1].get::<_, i32>(0), 3);
@@ -157,13 +159,13 @@ fn copy_in() {
     client
         .copy_in(
             "COPY foo FROM stdin",
-            &[],
+            &[] as &[i32],
             &mut &b"1\tsteven\n2\ttimothy"[..],
         )
         .unwrap();
 
     let rows = client
-        .query("SELECT id, name FROM foo ORDER BY id", &[])
+        .query("SELECT id, name FROM foo ORDER BY id", &[] as &[i32])
         .unwrap();
 
     assert_eq!(rows.len(), 2);
@@ -185,7 +187,7 @@ fn copy_out() {
         .unwrap();
 
     let mut reader = client
-        .copy_out("COPY foo (id, name) TO STDOUT", &[])
+        .copy_out("COPY foo (id, name) TO STDOUT", &[] as &[i32])
         .unwrap();
     let mut s = String::new();
     reader.read_to_string(&mut s).unwrap();
@@ -210,7 +212,7 @@ fn portal() {
     let mut transaction = client.transaction().unwrap();
 
     let portal = transaction
-        .bind("SELECT * FROM foo ORDER BY id", &[])
+        .bind("SELECT * FROM foo ORDER BY id", &[] as &[i32])
         .unwrap();
 
     let rows = transaction.query_portal(&portal, 2).unwrap();

--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -77,29 +77,35 @@ impl<'a> Transaction<'a> {
     }
 
     /// Like `Client::execute`.
-    pub fn execute<T>(&mut self, query: &T, params: &[&dyn ToSql]) -> Result<u64, Error>
+    pub fn execute<T, I>(&mut self, query: &T, params: impl IntoIterator<IntoIter = I, Item = I::Item>) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement,
+        I: Iterator,
+        I::Item: ToSql,
     {
         self.client.execute(query, params)
     }
 
     /// Like `Client::query`.
-    pub fn query<T>(&mut self, query: &T, params: &[&dyn ToSql]) -> Result<Vec<Row>, Error>
+    pub fn query<T, I>(&mut self, query: &T, params: impl IntoIterator<IntoIter = I, Item = I::Item>) -> Result<Vec<Row>, Error>
     where
         T: ?Sized + ToStatement,
+        I: Iterator,
+        I::Item: ToSql,
     {
         self.client.query(query, params)
     }
 
     /// Like `Client::query_iter`.
-    pub fn query_iter<T>(
+    pub fn query_iter<T, I>(
         &mut self,
         query: &T,
-        params: &[&dyn ToSql],
+        params: impl IntoIterator<IntoIter = I, Item = I::Item>,
     ) -> Result<QueryIter<'_>, Error>
     where
         T: ?Sized + ToStatement,
+        I: Iterator,
+        I::Item: ToSql,
     {
         self.client.query_iter(query, params)
     }
@@ -114,9 +120,11 @@ impl<'a> Transaction<'a> {
     /// # Panics
     ///
     /// Panics if the number of parameters provided does not match the number expected.
-    pub fn bind<T>(&mut self, query: &T, params: &[&dyn ToSql]) -> Result<Portal, Error>
+    pub fn bind<T, I>(&mut self, query: &T, params: impl IntoIterator<IntoIter = I, Item = I::Item>) -> Result<Portal, Error>
     where
         T: ?Sized + ToStatement,
+        I: Iterator,
+        I::Item: ToSql,
     {
         let statement = query.__statement(&mut self.client)?;
         self.client.get_mut().bind(&statement, params).wait()
@@ -143,27 +151,31 @@ impl<'a> Transaction<'a> {
     }
 
     /// Like `Client::copy_in`.
-    pub fn copy_in<T, R>(
+    pub fn copy_in<T, R, I>(
         &mut self,
         query: &T,
-        params: &[&dyn ToSql],
+        params: impl IntoIterator<IntoIter = I, Item = I::Item>,
         reader: R,
     ) -> Result<u64, Error>
     where
         T: ?Sized + ToStatement,
         R: Read,
+        I: Iterator,
+        I::Item: ToSql,
     {
         self.client.copy_in(query, params, reader)
     }
 
     /// Like `Client::copy_out`.
-    pub fn copy_out<T>(
+    pub fn copy_out<T, I>(
         &mut self,
         query: &T,
-        params: &[&dyn ToSql],
+        params: impl IntoIterator<IntoIter = I, Item = I::Item>,
     ) -> Result<CopyOutReader<'_>, Error>
     where
         T: ?Sized + ToStatement,
+        I: Iterator,
+        I::Item: ToSql,
     {
         self.client.copy_out(query, params)
     }

--- a/tokio-postgres-native-tls/src/test.rs
+++ b/tokio-postgres-native-tls/src/test.rs
@@ -26,10 +26,13 @@ where
 
     let prepare = client.prepare("SELECT 1::INT4");
     let statement = runtime.block_on(prepare).unwrap();
-    let select = client.query(&statement, &[]).collect().map(|rows| {
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].get::<_, i32>(0), 1);
-    });
+    let select = client
+        .query(&statement, &[] as &[i32])
+        .collect()
+        .map(|rows| {
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0].get::<_, i32>(0), 1);
+        });
     runtime.block_on(select).unwrap();
 
     drop(statement);

--- a/tokio-postgres-openssl/src/test.rs
+++ b/tokio-postgres-openssl/src/test.rs
@@ -24,10 +24,13 @@ where
 
     let prepare = client.prepare("SELECT 1::INT4");
     let statement = runtime.block_on(prepare).unwrap();
-    let select = client.query(&statement, &[]).collect().map(|rows| {
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].get::<_, i32>(0), 1);
-    });
+    let select = client
+        .query(&statement, &[] as &[i32])
+        .collect()
+        .map(|rows| {
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0].get::<_, i32>(0), 1);
+        });
     runtime.block_on(select).unwrap();
 
     drop(statement);

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -196,7 +196,15 @@ impl Client {
     /// # Panics
     ///
     /// Panics if the number of parameters provided does not match the number expected.
-    pub fn execute(&mut self, statement: &Statement, params: &[&dyn ToSql]) -> impls::Execute {
+    pub fn execute<I>(
+        &mut self,
+        statement: &Statement,
+        params: impl IntoIterator<IntoIter = I, Item = I::Item>,
+    ) -> impls::Execute
+    where
+        I: Iterator,
+        I::Item: ToSql,
+    {
         impls::Execute(self.0.execute(&statement.0, params))
     }
 
@@ -205,7 +213,15 @@ impl Client {
     /// # Panics
     ///
     /// Panics if the number of parameters provided does not match the number expected.
-    pub fn query(&mut self, statement: &Statement, params: &[&dyn ToSql]) -> impls::Query {
+    pub fn query<I>(
+        &mut self,
+        statement: &Statement,
+        params: impl IntoIterator<IntoIter = I, Item = I::Item>,
+    ) -> impls::Query
+    where
+        I: Iterator,
+        I::Item: ToSql,
+    {
         impls::Query(self.0.query(&statement.0, params))
     }
 
@@ -217,7 +233,15 @@ impl Client {
     /// # Panics
     ///
     /// Panics if the number of parameters provided does not match the number expected.
-    pub fn bind(&mut self, statement: &Statement, params: &[&dyn ToSql]) -> impls::Bind {
+    pub fn bind<I>(
+        &mut self,
+        statement: &Statement,
+        params: impl IntoIterator<IntoIter = I, Item = I::Item>,
+    ) -> impls::Bind
+    where
+        I: Iterator,
+        I::Item: ToSql,
+    {
         impls::Bind(self.0.bind(&statement.0, next_portal(), params))
     }
 
@@ -233,13 +257,15 @@ impl Client {
     ///
     /// The data in the provided stream is passed along to the server verbatim; it is the caller's responsibility to
     /// ensure it uses the proper format.
-    pub fn copy_in<S>(
+    pub fn copy_in<I, S>(
         &mut self,
         statement: &Statement,
-        params: &[&dyn ToSql],
+        params: impl IntoIterator<IntoIter = I, Item = I::Item>,
         stream: S,
     ) -> impls::CopyIn<S>
     where
+        I: Iterator,
+        I::Item: ToSql,
         S: Stream,
         S::Item: IntoBuf,
         <S::Item as IntoBuf>::Buf: Send,
@@ -250,7 +276,15 @@ impl Client {
     }
 
     /// Executes a `COPY TO STDOUT` statement, returning a stream of the resulting data.
-    pub fn copy_out(&mut self, statement: &Statement, params: &[&dyn ToSql]) -> impls::CopyOut {
+    pub fn copy_out<I>(
+        &mut self,
+        statement: &Statement,
+        params: impl IntoIterator<IntoIter = I, Item = I::Item>,
+    ) -> impls::CopyOut
+    where
+        I: Iterator,
+        I::Item: ToSql,
+    {
         impls::CopyOut(self.0.copy_out(&statement.0, params))
     }
 

--- a/tokio-postgres/tests/test/runtime.rs
+++ b/tokio-postgres/tests/test/runtime.rs
@@ -57,7 +57,7 @@ fn target_session_attrs_ok() {
         "host=localhost port=5433 user=postgres target_session_attrs=read-write",
         NoTls,
     );
-    runtime.block_on(f).unwrap();
+    let _r = runtime.block_on(f).unwrap();
 }
 
 #[test]

--- a/tokio-postgres/tests/test/types/mod.rs
+++ b/tokio-postgres/tests/test/types/mod.rs
@@ -41,7 +41,7 @@ where
     for &(ref val, ref repr) in checks.iter() {
         let prepare = client.prepare(&format!("SELECT {}::{}", repr, sql_type));
         let stmt = runtime.block_on(prepare).unwrap();
-        let query = client.query(&stmt, &[]).collect();
+        let query = client.query(&stmt, &[] as &[&i32]).collect();
         let rows = runtime.block_on(query).unwrap();
         let result = rows[0].get(0);
         assert_eq!(val, &result);
@@ -198,7 +198,7 @@ fn test_borrowed_text() {
 
     let prepare = client.prepare("SELECT 'foo'");
     let stmt = runtime.block_on(prepare).unwrap();
-    let query = client.query(&stmt, &[]).collect();
+    let query = client.query(&stmt, &[] as &[&i32]).collect();
     let rows = runtime.block_on(query).unwrap();
     let s: &str = rows[0].get(0);
     assert_eq!(s, "foo");
@@ -225,12 +225,12 @@ fn test_bpchar_params() {
 
     let prepare = client.prepare("INSERT INTO foo (b) VALUES ($1), ($2), ($3)");
     let stmt = runtime.block_on(prepare).unwrap();
-    let execute = client.execute(&stmt, &[&"12345", &"123", &None::<&'static str>]);
+    let execute = client.execute(&stmt, &[&"12345", &"123", &""]); // was &None::<&'static str>
     runtime.block_on(execute).unwrap();
 
     let prepare = client.prepare("SELECT b FROM foo ORDER BY id");
     let stmt = runtime.block_on(prepare).unwrap();
-    let query = client.query(&stmt, &[]).collect();
+    let query = client.query(&stmt, &[] as &[&i32]).collect();
     let res = runtime.block_on(query).unwrap();
 
     assert_eq!(
@@ -260,12 +260,12 @@ fn test_citext_params() {
 
     let prepare = client.prepare("INSERT INTO foo (b) VALUES ($1), ($2), ($3)");
     let stmt = runtime.block_on(prepare).unwrap();
-    let execute = client.execute(&stmt, &[&"foobar", &"FooBar", &None::<&'static str>]);
+    let execute = client.execute(&stmt, &[&"foobar", &"FooBar", &""]); // was &None::<&'static str>
     runtime.block_on(execute).unwrap();
 
     let prepare = client.prepare("SELECT b FROM foo WHERE b = 'FOOBAR' ORDER BY id");
     let stmt = runtime.block_on(prepare).unwrap();
-    let query = client.query(&stmt, &[]).collect();
+    let query = client.query(&stmt, &[] as &[&i32]).collect();
     let res = runtime.block_on(query).unwrap();
 
     assert_eq!(
@@ -298,7 +298,7 @@ fn test_borrowed_bytea() {
 
     let prepare = client.prepare("SELECT 'foo'::BYTEA");
     let stmt = runtime.block_on(prepare).unwrap();
-    let query = client.query(&stmt, &[]).collect();
+    let query = client.query(&stmt, &[] as &[&i32]).collect();
     let rows = runtime.block_on(query).unwrap();
     let s: &[u8] = rows[0].get(0);
     assert_eq!(s, b"foo");
@@ -358,7 +358,7 @@ where
 
     let prepare = client.prepare(&format!("SELECT 'NaN'::{}", sql_type));
     let stmt = runtime.block_on(prepare).unwrap();
-    let query = client.query(&stmt, &[]).collect();
+    let query = client.query(&stmt, &[] as &[&i32]).collect();
     let rows = runtime.block_on(query).unwrap();
     let val: T = rows[0].get(0);
     assert!(val != val);
@@ -385,7 +385,7 @@ fn test_pg_database_datname() {
 
     let prepare = client.prepare("SELECT datname FROM pg_database");
     let stmt = runtime.block_on(prepare).unwrap();
-    let query = client.query(&stmt, &[]).collect();
+    let query = client.query(&stmt, &[] as &[&i32]).collect();
     let rows = runtime.block_on(query).unwrap();
     assert_eq!(rows[0].get::<_, &str>(0), "postgres");
 }
@@ -533,7 +533,7 @@ fn domain() {
 
     let prepare = client.prepare("SELECT id FROM pg_temp.foo");
     let stmt = runtime.block_on(prepare).unwrap();
-    let query = client.query(&stmt, &[]).collect();
+    let query = client.query(&stmt, &[] as &[&i32]).collect();
     let rows = runtime.block_on(query).unwrap();
     assert_eq!(id, rows[0].get(0));
 }


### PR DESCRIPTION
Not happy that empty params (`&[]`) has to be explicity cast to `&[some type that implements ToSql (like i32)]`. Example: `&[] as &[i32]`.

Also, test `test_bpchar_params` fails because I don't know how to work with `None::<&'static str>`.